### PR TITLE
Updates fix setup scripts and deployment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ export DIST_OUTPUT_BUCKET=my-bucket-name # bucket where customized code will res
 export SOLUTION_NAME=my-solution-name
 export VERSION=my-version # version number for the customized code
 ```
--   When creating and using buckets it is recommeded to:
+-   When creating and using buckets it is recommended to:
 
     -   Use randomized names or uuid as part of your bucket naming strategy.
     -   Ensure buckets are not public.
@@ -101,14 +101,14 @@ chmod +x ./build-s3-dist.sh
 
 * Deploy the distributable to an Amazon S3 bucket in your account. _Note:_ you must have the AWS Command Line Interface installed.
 ```
-aws s3 cp global-s3-assets/ s3://my-bucket-name-<aws_region>/$SOLUTION_NAME/$VERSION/ --recursive --acl bucket-owner-full-control --profile aws-cred-profile-name
+aws s3 cp global-s3-assets/ s3://$DIST_OUTPUT_BUCKET/$SOLUTION_NAME/$VERSION/ --recursive
 ```
 
 * Get the link of the solution template uploaded to your Amazon S3 bucket.
 * Deploy the solution to your account by launching a new AWS CloudFormation stack using the link of the solution template in Amazon S3.
 
 ### Building the simulation engine Docker container for customization
-The simulation engine is a Docker container that is powered by AWS Fargate. Amazon ECS containers provisioned by [AWS Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html) contain the simulation engine that periodically polls a simulation queue for simulation requests. The simulation engine provides the logic for managing virtual devices and generating the simulated data to send to the target AWS IoT endpoint. After making your customizations to the simulation engine, you will need build a new Docker image.
+The simulation engine is a Docker container that is powered by AWS Fargate. Amazon ECS containers provisioned by [AWS Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html) contain the simulation engine that periodically polls a simulation queue for simulation requests. The simulation engine provides the logic for managing virtual devices and generating the simulated data to send to the target AWS IoT endpoint. After making your customization to the simulation engine, you will need build a new Docker image.
 
 ```
 cd ecr/remote-monitoring-of-iot-devices

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -16,6 +16,10 @@
 #
 #  - version-code: version of the package
 
+PUBLIC_ECR_REGISTRY=public.ecr.aws/aws-solutions
+PUBLIC_ECR_TAG=v1.0.0
+
+
 # Check to see if input has been provided:
 if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
     echo "Please provide the base source bucket name, trademark approved solution name and version where the lambda code will eventually reside."


### PR DESCRIPTION
Repo in the current form will not deploy because there are inconsistencies between commands in the README, environment variables set, and the run scripts.

1. Updated `deployment/build-s3-dist.sh` which did not have the `PUBLIC_ECR_REGISTRY` or `PUBLIC_ECR_TAG` set. Updated to point to the [ecr public repo](https://gallery.ecr.aws/aws-solutions/remote-monitoring-of-iot-devices). 
2. Updated README.md. The original `s3 cp ...` command did not take advantage of the original env variables setup for the S3 bucket. Additionally trimmed off the default profile and bucket ACL items as they are not required. 
3. 3. Updated README.md to fix spelling mistakes. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
